### PR TITLE
Omit whitespace after commas when printing out subtitles

### DIFF
--- a/lib/Subtitle/SubStationAlphaV4Plus/SectionLine.pm6
+++ b/lib/Subtitle/SubStationAlphaV4Plus/SectionLine.pm6
@@ -16,7 +16,7 @@ class Subtitle::SubStationAlphaV4Plus::Multivalue
     is Subtitle::SubStationAlphaV4Plus::KeyValue
 {
     has Cool @.values;
-    method value { @!values.join(', ') }
+    method value { @!values.join(',') }
     method Str { "$.key: { self.value }\n" }
 }
 

--- a/t/01-section-line.t
+++ b/t/01-section-line.t
@@ -33,9 +33,9 @@ subtest 'Format' => sub {
 
     my $format = Subtitle::SubStationAlphaV4Plus::Format.new(values => [ 'one', 'two', 'three' ]);
     ok $format, 'create';
-    is $format.Str, "Format: one, two, three\n", 'stringify';
+    is $format.Str, "Format: one,two,three\n", 'stringify';
     is $format.values, ['one', 'two', 'three'], 'values';
-    is $format.value, 'one, two, three', 'value';
+    is $format.value, 'one,two,three', 'value';
 }
 
 subtest 'Style' => sub {
@@ -45,9 +45,9 @@ subtest 'Style' => sub {
                     fields => ['first', 'second', 'third'],
                     values => [ 'one', 'two', 'three' ]);
     ok $style, 'create';
-    is $style.Str, "Style: one, two, three\n", 'stringify';
+    is $style.Str, "Style: one,two,three\n", 'stringify';
     is $style.values, ['one', 'two', 'three'], 'values';
-    is $style.value, 'one, two, three', 'value';
+    is $style.value, 'one,two,three', 'value';
     is $style.fields, ['first', 'second', 'third'], 'fields';
     is $style.get('first'), 'one', 'get first field';
     is $style.get('second'), 'two', 'get second field';

--- a/t/02-styles.t
+++ b/t/02-styles.t
@@ -9,9 +9,9 @@ my $subs = q:to/END/;
     Title: foo
 
     [V4+ Styles]
-    Format: Name, Fontname, Fontsize, PrimaryColour, Bold, Angle
-    Style: BoldStyle, BoldFont, 100, BoldColor, 1, 90
-    Style: Default, DefaultFont, 10, DefaultColor, 0, 180
+    Format: Name,Fontname,Fontsize,PrimaryColour,Bold,Angle
+    Style: BoldStyle,BoldFont,100,BoldColor,1,90
+    Style: Default,DefaultFont,10,DefaultColor,0,180
     END
 
 my $subtitles = SubtitleParser.parse_ssa($subs);

--- a/t/03-events.t
+++ b/t/03-events.t
@@ -7,10 +7,10 @@ my $subs = q:to/END/;
     Title: foo
 
     [Events]
-    Format: Layer, Name, Text
-    Comment: 0, Bob, Hello there
-    Dialogue: 10, Joe, Nice to meet you, too
-    Dialogue: 10, , {\i1}Still{\i0}, there is more\Nto see
+    Format: Layer,Name,Text
+    Comment: 0,Bob,Hello there
+    Dialogue: 10,Joe,Nice to meet you, too
+    Dialogue: 10,,{\i1}Still{\i0}, there is more\Nto see
     END
 
 my $subtitles = SubtitleParser.parse_ssa($subs);


### PR DESCRIPTION
Real subtitle files don't seem to have these spaces after a comma in Style
and Event lines.  The grammar still accepts them, though.